### PR TITLE
Use Dutch pairings for chess tournaments

### DIFF
--- a/src/app/servicos/torneio.service.ts
+++ b/src/app/servicos/torneio.service.ts
@@ -65,6 +65,7 @@ export class TorneioService {
     const vaTorneioSwiss = this.torneioManager.createTournament(null, {
       name: ipTorneio.nome,
       format: 'swiss',
+      dutch: true,
       seededPlayers: true,
       numberOfRounds: ipTorneio.qtde_rodadas,
     });


### PR DESCRIPTION
Dutch is the Swiss algorithm, except it attempts to balance color pairings for players. It is a better choice for chess tournaments. Just a suggestion.